### PR TITLE
Various fixes including Drupal 7 and Centos 7 compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Drupal-specific
 
 * No multi-sites support
 * No backup configuration
-* Drupal site configuration (`settings.xml`) has to be provided
+* Drupal site configuration (`settings.php`) has to be provided
 
 The module has been tested on the following operating systems. Testing and patches for other platforms are welcome.
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,7 +2,7 @@
 drupal::install_dir: /opt/drupal.org
 drupal::config_dir: /etc/drush
 drupal::log_dir: /var/log/drush
-drupal::cache_dir: /var/cache/puppet/archives
+drupal::cache_dir: $puppet::vardir/archives
 
 drupal::www_dir: /var/www
 drupal::www_process: www-data

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,6 +34,13 @@ class drupal::install inherits drupal {
     mode   => '0644',
   }
 
+  file { $drupal::cache_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
   file { $drupal::config_dir:
     ensure => directory,
     owner  => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,7 +17,7 @@ class drupal::install inherits drupal {
   $drush_download_url = "https://github.com/drush-ops/drush/archive/${drupal::drush_version}.tar.gz"
   $drush_install_dir = "${drupal::install_dir}/${drush_archive}"
 
-  if $::lsbdistid == 'Debian' and $::lsbmajdistrelease == '6' {
+  if $::osfamily == 'Debian' and $::lsbmajdistrelease == '6' {
     # Add phar extension to suhosin's whitelist
     $install_composer_command = "curl -sS ${drupal::composer_installer_url} | php -d suhosin.executor.include.whitelist=phar -- --install-dir=${composer_install_dir} --filename=`basename ${drupal::composer_path}`"
     $install_drush_dependencies_command = "php -d suhosin.executor.include.whitelist=phar ${drupal::composer_path} --working-dir=${drush_install_dir} install"

--- a/templates/drupal-update.sh.erb
+++ b/templates/drupal-update.sh.erb
@@ -32,7 +32,10 @@ fi
 ARGS="--verbose --root=${ROOT} --uri=${URI}"
 
 # enable maintenance mode
-$DRUSH vset site_offline 1 $ARGS
+$DRUSH vset maintenance_mode 1 $ARGS
+
+# Clear caches
+$DRUSH cc all $ARGS
 
 # apply outstanding update tasks
 $DRUSH updatedb --yes $ARGS


### PR DESCRIPTION
I've encountered a number of issues using this role which I've tried to supply fixes for below.

* Possible inaccuracy in readme where it refers to a settings.xml file
* Using puppet::vardir for cache instead of hard coding
* Using osfamily instead of lsbdistid so the lab_base package isn't required
* Add a missing file section for cache_dir
* Change drush vset to use maintenance_mode instead of site_offline, enabling support for D7
