### PR TITLE
Replace unencrypted git protocol when cloning fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     archive:
-      repo: "git://github.com/voxpupuli/puppet-archive"
+      repo: "https://github.com/voxpupuli/puppet-archive"
       ref: "v4.6.0"
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/